### PR TITLE
fix: WebSocket sub-protocol negotiation for graphql-transport-ws

### DIFF
--- a/internal/websocket/handler.go
+++ b/internal/websocket/handler.go
@@ -11,10 +11,15 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// SubprotocolGraphQLTransportWS is the WebSocket sub-protocol for the modern
+// graphql-ws protocol (https://github.com/enisdenjo/graphql-ws).
+const SubprotocolGraphQLTransportWS = "graphql-transport-ws"
+
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		return true // TODO: Make this configurable for production
 	},
+	Subprotocols: []string{SubprotocolGraphQLTransportWS},
 }
 
 // SchemaExecutor defines the interface for executing GraphQL subscriptions
@@ -99,17 +104,21 @@ func (h *connectionHandler) handle() {
 	}
 }
 
-// handleMessage processes a single WebSocket message
+// handleMessage processes a single WebSocket message.
+// Supports both the modern graphql-ws protocol and the legacy
+// subscriptions-transport-ws protocol for backward compatibility.
 func (h *connectionHandler) handleMessage(msg Message) error {
 	switch msg.Type {
 	case MessageTypeConnectionInit:
 		return h.handleConnectionInit(msg)
-	case MessageTypeSubscribe:
+	case MessageTypeSubscribe, LegacyMessageTypeStart:
 		return h.handleSubscribe(msg)
-	case MessageTypeComplete:
+	case MessageTypeComplete, LegacyMessageTypeStop:
 		return h.handleComplete(msg)
 	case MessageTypePing:
 		return h.handlePing(msg)
+	case LegacyMessageTypeConnectionTerminate:
+		return fmt.Errorf("connection terminated by client")
 	default:
 		return fmt.Errorf("unknown message type: %s", msg.Type)
 	}

--- a/internal/websocket/protocol.go
+++ b/internal/websocket/protocol.go
@@ -4,21 +4,31 @@ import (
 	"encoding/json"
 )
 
-// graphql-ws protocol message types
+// graphql-ws protocol message types (modern)
 // https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
 const (
 	// Client -> Server
-	MessageTypeConnectionInit      = "connection_init"
-	MessageTypeSubscribe           = "subscribe"
-	MessageTypeComplete            = "complete"
-	MessageTypePing                = "ping"
-	
+	MessageTypeConnectionInit = "connection_init"
+	MessageTypeSubscribe      = "subscribe"
+	MessageTypeComplete       = "complete"
+	MessageTypePing           = "ping"
+
 	// Server -> Client
-	MessageTypeConnectionAck       = "connection_ack"
-	MessageTypeNext                = "next"
-	MessageTypeError               = "error"
+	MessageTypeConnectionAck = "connection_ack"
+	MessageTypeNext          = "next"
+	MessageTypeError         = "error"
 	// MessageTypeComplete is used bidirectionally (already defined above)
-	MessageTypePong                = "pong"
+	MessageTypePong = "pong"
+)
+
+// Legacy subscriptions-transport-ws protocol message types.
+// These are accepted for backward compatibility with older clients and
+// gateways (e.g., Cosmo Router in AUTO sub-protocol mode).
+// https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+const (
+	LegacyMessageTypeStart               = "start"                // equivalent to "subscribe"
+	LegacyMessageTypeStop                = "stop"                 // equivalent to "complete"
+	LegacyMessageTypeConnectionTerminate = "connection_terminate" // client wants to close
 )
 
 // Message represents a graphql-ws protocol message


### PR DESCRIPTION
## Summary
- Advertise `graphql-transport-ws` sub-protocol during WebSocket handshake so gateways (Cosmo Router in AUTO mode) use the modern graphql-ws protocol
- Accept legacy `subscriptions-transport-ws` message types (`start`, `stop`, `connection_terminate`) for backward compatibility

Fixes `"unknown message type: start"` errors when the Cosmo Router connects with the legacy protocol due to missing sub-protocol negotiation.

## Test plan
- [ ] Verify subscriptions work through Cosmo Router with `GRAPHQL_WEBSOCKET_SUBPROTOCOL_AUTO`
- [ ] Verify direct WebSocket connections still work with graphql-ws clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)